### PR TITLE
fix(providers): corregir error de provider usado después de dispose

### DIFF
--- a/lib/domain/use_cases/category/add_category.dart
+++ b/lib/domain/use_cases/category/add_category.dart
@@ -1,0 +1,15 @@
+import 'package:expenses_app/domain/entities/category.dart';
+import 'package:expenses_app/domain/repositories/i_category_repository.dart';
+
+/// Caso de uso para agregar una nueva categoría.
+class AddCategory {
+  final ICategoryRepository _repository;
+
+  /// Crea una instancia de [AddCategory].
+  AddCategory(this._repository);
+
+  /// Ejecuta el caso de uso para agregar una categoría.
+  Future<void> execute(Category category) {
+    return _repository.addCategory(category);
+  }
+}

--- a/lib/domain/use_cases/category/get_all_categories_stream.dart
+++ b/lib/domain/use_cases/category/get_all_categories_stream.dart
@@ -1,0 +1,15 @@
+import 'package:expenses_app/domain/entities/category.dart';
+import 'package:expenses_app/domain/repositories/i_category_repository.dart';
+
+/// Caso de uso para obtener todas las categorías como stream.
+class GetAllCategoriesStream {
+  final ICategoryRepository _repository;
+
+  /// Crea una instancia de [GetAllCategoriesStream].
+  GetAllCategoriesStream(this._repository);
+
+  /// Ejecuta el caso de uso para obtener un stream de todas las categorías.
+  Stream<List<Category>> execute() {
+    return _repository.getAllCategoriesStream();
+  }
+}

--- a/lib/domain/use_cases/transaction/add_transaction.dart
+++ b/lib/domain/use_cases/transaction/add_transaction.dart
@@ -1,0 +1,15 @@
+import 'package:expenses_app/domain/entities/transaction.dart';
+import 'package:expenses_app/domain/repositories/i_transaction_repository.dart';
+
+/// Caso de uso para agregar una nueva transacción.
+class AddTransaction {
+  final ITransactionRepository _repository;
+
+  /// Crea una instancia de [AddTransaction].
+  AddTransaction(this._repository);
+
+  /// Ejecuta el caso de uso para agregar una transacción.
+  Future<void> execute(Transaction transaction) {
+    return _repository.addTransaction(transaction);
+  }
+}

--- a/lib/domain/use_cases/transaction/delete_transaction.dart
+++ b/lib/domain/use_cases/transaction/delete_transaction.dart
@@ -1,0 +1,14 @@
+import 'package:expenses_app/domain/repositories/i_transaction_repository.dart';
+
+/// Caso de uso para eliminar una transacción.
+class DeleteTransaction {
+  final ITransactionRepository _repository;
+
+  /// Crea una instancia de [DeleteTransaction].
+  DeleteTransaction(this._repository);
+
+  /// Ejecuta el caso de uso para eliminar una transacción por su ID.
+  Future<void> execute(int transactionId) {
+    return _repository.deleteTransaction(transactionId);
+  }
+}

--- a/lib/domain/use_cases/transaction/get_transactions_stream.dart
+++ b/lib/domain/use_cases/transaction/get_transactions_stream.dart
@@ -1,0 +1,23 @@
+import 'package:expenses_app/domain/entities/transaction.dart';
+import 'package:expenses_app/domain/repositories/i_transaction_repository.dart';
+
+/// Caso de uso para obtener transacciones como stream.
+class GetTransactionsStream {
+  final ITransactionRepository _repository;
+
+  /// Crea una instancia de [GetTransactionsStream].
+  GetTransactionsStream(this._repository);
+
+  /// Ejecuta el caso de uso para obtener un stream de transacciones.
+  /// 
+  /// Opcionalmente puede filtrar por rango de fechas.
+  Stream<List<Transaction>> execute({
+    DateTime? startDate,
+    DateTime? endDate,
+  }) {
+    return _repository.getTransactionsStream(
+      startDate: startDate,
+      endDate: endDate,
+    );
+  }
+}

--- a/lib/presentation/providers/category_provider.dart
+++ b/lib/presentation/providers/category_provider.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:expenses_app/domain/entities/category.dart';
 import 'package:expenses_app/domain/repositories/i_category_repository.dart';
 
+/// Provider para gestionar el estado de las categorías.
 class CategoryProvider extends ChangeNotifier {
   final ICategoryRepository _categoryRepository;
+  StreamSubscription<List<Category>>? _categoriesSubscription;
+  bool _isDisposed = false;
+  
   List<Category> categories = [];
   bool isLoading = true;
 
@@ -12,22 +17,35 @@ class CategoryProvider extends ChangeNotifier {
   }
 
   void _loadCategories() {
-    _categoryRepository.getAllCategoriesStream().listen((categoryList) {
+    _categoriesSubscription?.cancel();
+    _categoriesSubscription = _categoryRepository.getAllCategoriesStream().listen((categoryList) {
+      if (_isDisposed) return; // Evitar actualizar si el provider ya fue disposed
+      
       categories = categoryList;
       isLoading = false;
       notifyListeners();
     });
   }
 
+  /// Agrega una nueva categoría.
   Future<void> addCategory(Category category) async {
     await _categoryRepository.addCategory(category);
   }
 
+  /// Actualiza una categoría existente.
   Future<void> updateCategory(Category category) async {
     await _categoryRepository.updateCategory(category);
   }
 
+  /// Elimina una categoría por su ID.
   Future<void> deleteCategory(int categoryId) async {
     await _categoryRepository.deleteCategory(categoryId);
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    _categoriesSubscription?.cancel();
+    super.dispose();
   }
 }


### PR DESCRIPTION
## 🐛 Problema Solucionado
Corrige el error que pausaba la app al crear categorías:
"A CategoryProvider was used after being disposed."

## 📋 Cambios
- CategoryProvider y OverviewProvider: Control de lifecycle
- Casos de uso completados para arquitectura clean
- Memory leaks prevenidos

## 🚀 Resultado
✅ Creación fluida de categorías sin errores
✅ Arquitectura completada